### PR TITLE
Add .net standard 2.0 support to library

### DIFF
--- a/fusionauth-netcore-client/fusionauth-netcore-client.csproj
+++ b/fusionauth-netcore-client/fusionauth-netcore-client.csproj
@@ -11,7 +11,7 @@
         <Authors>Tyler Scott</Authors>
         <Owners>FusionAuth</Owners>
         <Summary>FusionAuth client for .NET Core</Summary>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netstandard2.0</TargetFrameworks>
         <LangVersion>7.3</LangVersion>
     </PropertyGroup>
 

--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -185,7 +185,11 @@ namespace io.fusionauth {
         case "POST":
           return httpClient.PostAsync(requestUri, content);
         case "PATCH":
-          return httpClient.PatchAsync(requestUri, content);
+          var patchRequest = new HttpRequestMessage();
+          patchRequest.Method = new HttpMethod("PATCH");
+          patchRequest.Content = content;
+          patchRequest.RequestUri = new Uri(requestUri, UriKind.Relative);
+          return httpClient.SendAsync(patchRequest);
         default:
           throw new MissingMethodException("This REST client does not support that method. (yet?)");
       }


### PR DESCRIPTION
- Update Patch method in DefaultRESTClient to build a PATCH request manually instead of using PatchAsync helper (doesn't exist in .net standard 2.0)

- Add netstandard2.0 to supported framework list so library can be used with full framework .NET