### PR TITLE
Fix serialisation error for bool? (#26)

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/IRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/IRESTClient.cs
@@ -95,6 +95,15 @@ namespace io.fusionauth {
       return withParameter(name, value ? "true" : "false");
     }
 
+    public IRESTClient withParameter(string name, bool? value) {
+        if (!value.HasValue)
+        {
+            return this;
+        }
+
+        return withParameter(name, value.Value);
+    }
+
     public IRESTClient withParameter(string name, object value) {
       if (value == null) {
         return this;


### PR DESCRIPTION
Add an overload for `bool?` and handle the case where the parameter is null. Indeed, with `bool?`, the call to `withParameter` is using the overload that takes object rather than the bool one.

Fix #26 