### PR TITLE
Make enum fields nullable

### DIFF
--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/Key.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/Key.cs
@@ -27,7 +27,7 @@ namespace io.fusionauth.domain {
    */
   public class Key {
 
-    public KeyAlgorithm algorithm;
+    public KeyAlgorithm? algorithm;
 
     public string certificate;
 
@@ -57,7 +57,7 @@ namespace io.fusionauth.domain {
 
     public string secret;
 
-    public KeyType type;
+    public KeyType? type;
 
     public Key with(Action<Key> action) {
       action(this);


### PR DESCRIPTION
In C#, enums are just glorified int and are therefore not nullable. When building a `Key` without providing a type or an algorithm, they will have a default value instead of being null.

You might want to go through all the domain to make optional enums nullable.

Associated PR in the builder: https://github.com/FusionAuth/fusionauth-client-builder/pull/24

Fix #31