### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-netcore-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-netcore-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-netcore-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-netcore-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/fusionauth-netcore-client-test/fusionauth-netcore-client-test/fusionauth-netcore-client-test.csproj
+++ b/fusionauth-netcore-client-test/fusionauth-netcore-client-test/fusionauth-netcore-client-test.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace></RootNamespace>
-        <PackageVersion>1.21.1</PackageVersion>
+        <PackageVersion>1.22.0</PackageVersion>
         <AssemblyName>FusionAuth.Client.Test</AssemblyName>
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>

--- a/fusionauth-netcore-client-test/fusionauth-netcore-client-test/fusionauth-netcore-client-test.csproj
+++ b/fusionauth-netcore-client-test/fusionauth-netcore-client-test/fusionauth-netcore-client-test.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace></RootNamespace>
-        <PackageVersion>1.22.0</PackageVersion>
+        <PackageVersion>1.23.0</PackageVersion>
         <AssemblyName>FusionAuth.Client.Test</AssemblyName>
         <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/Application.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/Application.cs
@@ -15,7 +15,7 @@
  */
 
 
-using io.fusionauth.domain.provider;
+using io.fusionauth.domain.connector;
 using io.fusionauth.domain.oauth2;
 using System.Collections.Generic;
 using System;

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/Application.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/Application.cs
@@ -15,7 +15,7 @@
  */
 
 
-using io.fusionauth.domain.connector;
+using io.fusionauth.domain.provider;
 using io.fusionauth.domain.oauth2;
 using System.Collections.Generic;
 using System;

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/LambdaConfiguration.cs
@@ -15,7 +15,7 @@
  */
 
 
-using io.fusionauth.domain.provider;
+using io.fusionauth.domain.connector;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/LambdaConfiguration.cs
@@ -15,7 +15,7 @@
  */
 
 
-using io.fusionauth.domain.connector;
+using io.fusionauth.domain.provider;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/api/MessageTemplateRequest.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/api/MessageTemplateRequest.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using io.fusionauth.domain.message;
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.api {
+
+  /**
+   * A Message Template Request to the API
+   *
+   * @author Michael Sleevi
+   */
+  public class MessageTemplateRequest {
+
+    public MessageTemplate messageTemplate;
+
+    public MessageTemplateRequest with(Action<MessageTemplateRequest> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/api/MessageTemplateResponse.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/api/MessageTemplateResponse.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using io.fusionauth.domain.message;
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.api {
+
+  public class MessageTemplateResponse {
+
+    public MessageTemplate messageTemplate;
+
+    public List<MessageTemplate> messageTemplates;
+
+    public MessageTemplateResponse with(Action<MessageTemplateResponse> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/api/PreviewMessageTemplateRequest.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/api/PreviewMessageTemplateRequest.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using io.fusionauth.domain.message;
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.api {
+
+  /**
+   * @author Michael Sleevi
+   */
+  public class PreviewMessageTemplateRequest {
+
+    public string locale;
+
+    public MessageTemplate messageTemplate;
+
+    public PreviewMessageTemplateRequest with(Action<PreviewMessageTemplateRequest> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/api/PreviewMessageTemplateResponse.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/api/PreviewMessageTemplateResponse.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using com.inversoft.error;
+using io.fusionauth.domain.message;
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.api {
+
+  public class PreviewMessageTemplateResponse {
+
+    public Errors errors;
+
+    public Message message;
+
+    public PreviewMessageTemplateResponse with(Action<PreviewMessageTemplateResponse> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LDAPConnectorConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LDAPConnectorConfiguration.cs
@@ -15,7 +15,6 @@
  */
 
 
-using io.fusionauth.domain.provider;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LDAPConnectorConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LDAPConnectorConfiguration.cs
@@ -15,6 +15,7 @@
  */
 
 
+using io.fusionauth.domain.provider;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LambdaConfiguration.cs
@@ -15,7 +15,6 @@
  */
 
 
-using io.fusionauth.domain.provider;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/connector/LambdaConfiguration.cs
@@ -15,6 +15,7 @@
  */
 
 
+using io.fusionauth.domain.provider;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/message/Message.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/message/Message.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.message {
+
+  /**
+   * An incredible simplified view of a message
+   *
+   * @author Michael Sleevi
+   */
+  public class Message {
+
+    public string text;
+
+    public Message with(Action<Message> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/message/MessageTemplate.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/message/MessageTemplate.cs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+
+using io.fusionauth.domain;
+using System.Collections.Generic;
+using System;
+
+namespace io.fusionauth.domain.message {
+
+  /**
+   * Stores an message template used to distribute messages;
+   *
+   * @author Michael Sleevi
+   */
+  public class MessageTemplate {
+
+    public string defaultTemplate;
+
+    public Guid? id;
+
+    public DateTimeOffset? insertInstant;
+
+    public DateTimeOffset? lastUpdateInstant;
+
+    public LocalizedStrings localizedTemplates;
+
+    public string name;
+
+    public MessageTemplate with(Action<MessageTemplate> action) {
+      action(this);
+      return this;
+    }
+  }
+}

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/BaseIdentityProvider.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/BaseIdentityProvider.cs
@@ -16,6 +16,7 @@
 
 
 using io.fusionauth.domain;
+using io.fusionauth.domain.connector;
 using io.fusionauth.converters.helpers;
 using System.Collections.Generic;
 using System;

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/BaseIdentityProvider.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/BaseIdentityProvider.cs
@@ -16,7 +16,6 @@
 
 
 using io.fusionauth.domain;
-using io.fusionauth.domain.connector;
 using io.fusionauth.converters.helpers;
 using System.Collections.Generic;
 using System;

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/LambdaConfiguration.cs
@@ -15,6 +15,7 @@
  */
 
 
+using io.fusionauth.domain.connector;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/LambdaConfiguration.cs
+++ b/fusionauth-netcore-client/domain/io/fusionauth/domain/provider/LambdaConfiguration.cs
@@ -15,7 +15,6 @@
  */
 
 
-using io.fusionauth.domain.connector;
 using System.Collections.Generic;
 using System;
 

--- a/fusionauth-netcore-client/fusionauth-netcore-client.csproj
+++ b/fusionauth-netcore-client/fusionauth-netcore-client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace></RootNamespace>
-        <PackageVersion>1.21.1</PackageVersion>
+        <PackageVersion>1.22.0</PackageVersion>
         <Title>FusionAuth .net Standard Client</Title>
         <AssemblyName>FusionAuth.Client</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/fusionauth-netcore-client/fusionauth-netcore-client.csproj
+++ b/fusionauth-netcore-client/fusionauth-netcore-client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace></RootNamespace>
-        <PackageVersion>1.22.0</PackageVersion>
+        <PackageVersion>1.23.0</PackageVersion>
         <Title>FusionAuth .net Standard Client</Title>
         <AssemblyName>FusionAuth.Client</AssemblyName>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
@@ -1496,6 +1496,15 @@ namespace io.fusionauth {
     }
 
     /// <inheritdoc/>
+    public Task<ClientResponse<PreviewMessageTemplateResponse>> RetrieveMessageTemplatePreviewAsync(PreviewMessageTemplateRequest request) {
+      return buildClient()
+          .withUri("/api/message/template/preview")
+          .withJSONBody(request)
+          .withMethod("Post")
+          .goAsync<PreviewMessageTemplateResponse>();
+    }
+
+    /// <inheritdoc/>
     public Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplatesAsync() {
       return buildClient()
           .withUri("/api/message/template")

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
@@ -249,6 +249,16 @@ namespace io.fusionauth {
     }
 
     /// <inheritdoc/>
+    public Task<ClientResponse<MessageTemplateResponse>> CreateMessageTemplateAsync(Guid? messageTemplateId, MessageTemplateRequest request) {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withUriSegment(messageTemplateId)
+          .withJSONBody(request)
+          .withMethod("Post")
+          .goAsync<MessageTemplateResponse>();
+    }
+
+    /// <inheritdoc/>
     public Task<ClientResponse<TenantResponse>> CreateTenantAsync(Guid? tenantId, TenantRequest request) {
       return buildClient()
           .withUri("/api/tenant")
@@ -475,6 +485,15 @@ namespace io.fusionauth {
       return buildClient()
           .withUri("/api/lambda")
           .withUriSegment(lambdaId)
+          .withMethod("Delete")
+          .goAsync<RESTVoid>();
+    }
+
+    /// <inheritdoc/>
+    public Task<ClientResponse<RESTVoid>> DeleteMessageTemplateAsync(Guid? messageTemplateId) {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withUriSegment(messageTemplateId)
           .withMethod("Delete")
           .goAsync<RESTVoid>();
     }
@@ -926,6 +945,16 @@ namespace io.fusionauth {
           .withJSONBody(request)
           .withMethod("Patch")
           .goAsync<LambdaResponse>();
+    }
+
+    /// <inheritdoc/>
+    public Task<ClientResponse<MessageTemplateResponse>> PatchMessageTemplateAsync(Guid? messageTemplateId, Dictionary<string, object> request) {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withUriSegment(messageTemplateId)
+          .withJSONBody(request)
+          .withMethod("Patch")
+          .goAsync<MessageTemplateResponse>();
     }
 
     /// <inheritdoc/>
@@ -1455,6 +1484,23 @@ namespace io.fusionauth {
           .withParameter("end", end)
           .withMethod("Get")
           .goAsync<LoginReportResponse>();
+    }
+
+    /// <inheritdoc/>
+    public Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplateAsync(Guid? messageTemplateId) {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withUriSegment(messageTemplateId)
+          .withMethod("Get")
+          .goAsync<MessageTemplateResponse>();
+    }
+
+    /// <inheritdoc/>
+    public Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplatesAsync() {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withMethod("Get")
+          .goAsync<MessageTemplateResponse>();
     }
 
     /// <inheritdoc/>
@@ -2064,6 +2110,16 @@ namespace io.fusionauth {
           .withJSONBody(request)
           .withMethod("Put")
           .goAsync<LambdaResponse>();
+    }
+
+    /// <inheritdoc/>
+    public Task<ClientResponse<MessageTemplateResponse>> UpdateMessageTemplateAsync(Guid? messageTemplateId, MessageTemplateRequest request) {
+      return buildClient()
+          .withUri("/api/message/template")
+          .withUriSegment(messageTemplateId)
+          .withJSONBody(request)
+          .withMethod("Put")
+          .goAsync<MessageTemplateResponse>();
     }
 
     /// <inheritdoc/>

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
@@ -778,6 +778,11 @@ namespace io.fusionauth {
     }
 
     /// <inheritdoc/>
+    public ClientResponse<PreviewMessageTemplateResponse> RetrieveMessageTemplatePreview(PreviewMessageTemplateRequest request) {
+      return client.RetrieveMessageTemplatePreviewAsync(request).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
     public ClientResponse<MessageTemplateResponse> RetrieveMessageTemplates() {
       return client.RetrieveMessageTemplatesAsync().GetAwaiter().GetResult();
     }

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
@@ -131,6 +131,11 @@ namespace io.fusionauth {
     }
 
     /// <inheritdoc/>
+    public ClientResponse<MessageTemplateResponse> CreateMessageTemplate(Guid? messageTemplateId, MessageTemplateRequest request) {
+      return client.CreateMessageTemplateAsync(messageTemplateId, request).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
     public ClientResponse<TenantResponse> CreateTenant(Guid? tenantId, TenantRequest request) {
       return client.CreateTenantAsync(tenantId, request).GetAwaiter().GetResult();
     }
@@ -249,6 +254,11 @@ namespace io.fusionauth {
     /// <inheritdoc/>
     public ClientResponse<RESTVoid> DeleteLambda(Guid? lambdaId) {
       return client.DeleteLambdaAsync(lambdaId).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public ClientResponse<RESTVoid> DeleteMessageTemplate(Guid? messageTemplateId) {
+      return client.DeleteMessageTemplateAsync(messageTemplateId).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
@@ -465,6 +475,11 @@ namespace io.fusionauth {
     /// <inheritdoc/>
     public ClientResponse<LambdaResponse> PatchLambda(Guid? lambdaId, Dictionary<string, object> request) {
       return client.PatchLambdaAsync(lambdaId, request).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public ClientResponse<MessageTemplateResponse> PatchMessageTemplate(Guid? messageTemplateId, Dictionary<string, object> request) {
+      return client.PatchMessageTemplateAsync(messageTemplateId, request).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
@@ -755,6 +770,16 @@ namespace io.fusionauth {
     /// <inheritdoc/>
     public ClientResponse<LoginReportResponse> RetrieveLoginReport(Guid? applicationId, long? start, long? end) {
       return client.RetrieveLoginReportAsync(applicationId, start, end).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public ClientResponse<MessageTemplateResponse> RetrieveMessageTemplate(Guid? messageTemplateId) {
+      return client.RetrieveMessageTemplateAsync(messageTemplateId).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public ClientResponse<MessageTemplateResponse> RetrieveMessageTemplates() {
+      return client.RetrieveMessageTemplatesAsync().GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>
@@ -1082,6 +1107,11 @@ namespace io.fusionauth {
     /// <inheritdoc/>
     public ClientResponse<LambdaResponse> UpdateLambda(Guid? lambdaId, LambdaRequest request) {
       return client.UpdateLambdaAsync(lambdaId, request).GetAwaiter().GetResult();
+    }
+
+    /// <inheritdoc/>
+    public ClientResponse<MessageTemplateResponse> UpdateMessageTemplate(Guid? messageTemplateId, MessageTemplateRequest request) {
+      return client.UpdateMessageTemplateAsync(messageTemplateId, request).GetAwaiter().GetResult();
     }
 
     /// <inheritdoc/>

--- a/fusionauth-netcore-client/src/io/fusionauth/IFusionAuthClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/IFusionAuthClient.cs
@@ -2103,6 +2103,19 @@ namespace io.fusionauth {
     Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplateAsync(Guid? messageTemplateId);
 
     /// <summary>
+    /// Creates a preview of the message template provided in the request, normalized to a given locale.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="request"> The request that contains the email template and optionally a locale to render it in.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<PreviewMessageTemplateResponse>> RetrieveMessageTemplatePreviewAsync(PreviewMessageTemplateRequest request);
+
+    /// <summary>
     /// Retrieves all of the message templates.
     /// This is an asynchronous method.
     /// </summary>
@@ -5122,6 +5135,18 @@ namespace io.fusionauth {
    /// IOException.
    /// </returns>
    ClientResponse<MessageTemplateResponse> RetrieveMessageTemplate(Guid? messageTemplateId);
+
+   /// <summary>
+   /// Creates a preview of the message template provided in the request, normalized to a given locale.
+   /// </summary>
+   /// <param name="request"> The request that contains the email template and optionally a locale to render it in.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<PreviewMessageTemplateResponse> RetrieveMessageTemplatePreview(PreviewMessageTemplateRequest request);
 
    /// <summary>
    /// Retrieves all of the message templates.

--- a/fusionauth-netcore-client/src/io/fusionauth/IFusionAuthClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/IFusionAuthClient.cs
@@ -303,6 +303,20 @@ namespace io.fusionauth {
     Task<ClientResponse<LambdaResponse>> CreateLambdaAsync(Guid? lambdaId, LambdaRequest request);
 
     /// <summary>
+    /// Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="messageTemplateId"> (Optional) The Id for the template. If not provided a secure random UUID will be generated.</param>
+    /// <param name="request"> The request object that contains all of the information used to create the message template.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<MessageTemplateResponse>> CreateMessageTemplateAsync(Guid? messageTemplateId, MessageTemplateRequest request);
+
+    /// <summary>
     /// Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
     /// This is an asynchronous method.
     /// </summary>
@@ -628,6 +642,19 @@ namespace io.fusionauth {
     /// IOException.
     /// </returns>
     Task<ClientResponse<RESTVoid>> DeleteLambdaAsync(Guid? lambdaId);
+
+    /// <summary>
+    /// Deletes the message template for the given Id.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="messageTemplateId"> The Id of the message template to delete.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<RESTVoid>> DeleteMessageTemplateAsync(Guid? messageTemplateId);
 
     /// <summary>
     /// Deletes the user registration for the given user and application.
@@ -1279,6 +1306,20 @@ namespace io.fusionauth {
     /// IOException.
     /// </returns>
     Task<ClientResponse<LambdaResponse>> PatchLambdaAsync(Guid? lambdaId, Dictionary<string, object> request);
+
+    /// <summary>
+    /// Updates, via PATCH, the message template with the given Id.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="messageTemplateId"> The Id of the message template to update.</param>
+    /// <param name="request"> The request that contains just the new message template information.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<MessageTemplateResponse>> PatchMessageTemplateAsync(Guid? messageTemplateId, Dictionary<string, object> request);
 
     /// <summary>
     /// Updates, via PATCH, the registration for the user with the given id and the application defined in the request.
@@ -2047,6 +2088,31 @@ namespace io.fusionauth {
     /// IOException.
     /// </returns>
     Task<ClientResponse<LoginReportResponse>> RetrieveLoginReportAsync(Guid? applicationId, long? start, long? end);
+
+    /// <summary>
+    /// Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="messageTemplateId"> (Optional) The Id of the message template.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplateAsync(Guid? messageTemplateId);
+
+    /// <summary>
+    /// Retrieves all of the message templates.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<MessageTemplateResponse>> RetrieveMessageTemplatesAsync();
 
     /// <summary>
     /// Retrieves the monthly active user report between the two instants. If you specify an application id, it will only
@@ -2936,6 +3002,20 @@ namespace io.fusionauth {
     Task<ClientResponse<LambdaResponse>> UpdateLambdaAsync(Guid? lambdaId, LambdaRequest request);
 
     /// <summary>
+    /// Updates the message template with the given Id.
+    /// This is an asynchronous method.
+    /// </summary>
+    /// <param name="messageTemplateId"> The Id of the message template to update.</param>
+    /// <param name="request"> The request that contains all of the new message template information.</param>
+    /// <returns>
+    /// When successful, the response will contain the log of the action. If there was a validation error or any
+    /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+    /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+    /// IOException.
+    /// </returns>
+    Task<ClientResponse<MessageTemplateResponse>> UpdateMessageTemplateAsync(Guid? messageTemplateId, MessageTemplateRequest request);
+
+    /// <summary>
     /// Updates the registration for the user with the given id and the application defined in the request.
     /// This is an asynchronous method.
     /// </summary>
@@ -3373,6 +3453,19 @@ namespace io.fusionauth {
    ClientResponse<LambdaResponse> CreateLambda(Guid? lambdaId, LambdaRequest request);
 
    /// <summary>
+   /// Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   /// </summary>
+   /// <param name="messageTemplateId"> (Optional) The Id for the template. If not provided a secure random UUID will be generated.</param>
+   /// <param name="request"> The request object that contains all of the information used to create the message template.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<MessageTemplateResponse> CreateMessageTemplate(Guid? messageTemplateId, MessageTemplateRequest request);
+
+   /// <summary>
    /// Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    /// </summary>
    /// <param name="tenantId"> (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.</param>
@@ -3674,6 +3767,18 @@ namespace io.fusionauth {
    /// IOException.
    /// </returns>
    ClientResponse<RESTVoid> DeleteLambda(Guid? lambdaId);
+
+   /// <summary>
+   /// Deletes the message template for the given Id.
+   /// </summary>
+   /// <param name="messageTemplateId"> The Id of the message template to delete.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<RESTVoid> DeleteMessageTemplate(Guid? messageTemplateId);
 
    /// <summary>
    /// Deletes the user registration for the given user and application.
@@ -4282,6 +4387,19 @@ namespace io.fusionauth {
    /// IOException.
    /// </returns>
    ClientResponse<LambdaResponse> PatchLambda(Guid? lambdaId, Dictionary<string, object> request);
+
+   /// <summary>
+   /// Updates, via PATCH, the message template with the given Id.
+   /// </summary>
+   /// <param name="messageTemplateId"> The Id of the message template to update.</param>
+   /// <param name="request"> The request that contains just the new message template information.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<MessageTemplateResponse> PatchMessageTemplate(Guid? messageTemplateId, Dictionary<string, object> request);
 
    /// <summary>
    /// Updates, via PATCH, the registration for the user with the given id and the application defined in the request.
@@ -4992,6 +5110,29 @@ namespace io.fusionauth {
    /// IOException.
    /// </returns>
    ClientResponse<LoginReportResponse> RetrieveLoginReport(Guid? applicationId, long? start, long? end);
+
+   /// <summary>
+   /// Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   /// </summary>
+   /// <param name="messageTemplateId"> (Optional) The Id of the message template.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<MessageTemplateResponse> RetrieveMessageTemplate(Guid? messageTemplateId);
+
+   /// <summary>
+   /// Retrieves all of the message templates.
+   /// </summary>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<MessageTemplateResponse> RetrieveMessageTemplates();
 
    /// <summary>
    /// Retrieves the monthly active user report between the two instants. If you specify an application id, it will only
@@ -5814,6 +5955,19 @@ namespace io.fusionauth {
    /// IOException.
    /// </returns>
    ClientResponse<LambdaResponse> UpdateLambda(Guid? lambdaId, LambdaRequest request);
+
+   /// <summary>
+   /// Updates the message template with the given Id.
+   /// </summary>
+   /// <param name="messageTemplateId"> The Id of the message template to update.</param>
+   /// <param name="request"> The request that contains all of the new message template information.</param>
+   /// <returns>
+   /// When successful, the response will contain the log of the action. If there was a validation error or any
+   /// other type of error, this will return the Errors object in the response. Additionally, if FusionAuth could not be
+   /// contacted because it is down or experiencing a failure, the response will contain an Exception, which could be an
+   /// IOException.
+   /// </returns>
+   ClientResponse<MessageTemplateResponse> UpdateMessageTemplate(Guid? messageTemplateId, MessageTemplateRequest request);
 
    /// <summary>
    /// Updates the registration for the user with the given id and the application defined in the request.


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`