### PR TITLE
Update DateTimeOffsetConverter.cs

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/converters/DateTimeOffsetConverter.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/converters/DateTimeOffsetConverter.cs
@@ -1,42 +1,40 @@
 using System;
 using Newtonsoft.Json;
 
-namespace io.fusionauth.converters {
-  public class DateTimeOffsetConverter : JsonConverter
-  {
-    public static readonly long GAP = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).Ticks;
-
-    public override bool CanRead => true;
-
-    public override bool CanWrite => true;
-
-    public override bool CanConvert(Type objectType)
+namespace io.fusionauth.converters
+{
+    public class DateTimeOffsetConverter : JsonConverter
     {
-      return objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?);
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(DateTimeOffset) || objectType == typeof(DateTimeOffset?);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var utc = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddSeconds((long)reader.Value);
+            return new DateTimeOffset(utc);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            var epoch = ((DateTimeOffset)value - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+            writer.WriteValue(epoch);
+        }
     }
-
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-    {
-      if (reader.TokenType == JsonToken.Null)
-      {
-        return null;
-      }
-
-      var value = (long) reader.Value * TimeSpan.TicksPerMillisecond;
-      return new DateTimeOffset(value + GAP, TimeSpan.Zero);
-    }
-
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-    {
-      if (value == null)
-      {
-        return;
-      }
-
-      var dto = (DateTimeOffset) value;
-      var ticks = dto.UtcTicks - GAP;
-      var millis = ticks / TimeSpan.TicksPerMillisecond;
-      writer.WriteValue(millis);
-    }
-  }
 }


### PR DESCRIPTION
There is a bug in the ValidateJWT(string encodedJWT) method response.  The DateTimeOffset values are incorrect, so I started poking around to see if I could find something that looked strange and I believe I found it.

This code change should fix your conversions, if my assumptions are correct on what you are trying to accomplish:

ReadJson passes in (JsonReader reader = an epoch time (seconds since Jan 1, 1970) ex: 1629820759 for today) and converts to DateTimeOffset (UTC)
WriteJson is converting back from UTC to epoch and writes the epoch value to json

-RD