### PR TITLE
Allow API keys that contains '=' characters

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -164,7 +164,11 @@ namespace io.fusionauth {
 
     private Task<HttpResponseMessage> baseRequest() {
       foreach (var (key, value) in headers.Select(x => (x.Key, x.Value))) {
-        httpClient.DefaultRequestHeaders.Add(key, value);
+        if (key == "Authorization") {
+          httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
+        } else {
+          httpClient.DefaultRequestHeaders.Add(key, value);
+        }
       }
 
       var requestUri = getFullUri();


### PR DESCRIPTION
Now using TryAddWithoutValidation when adding HttpClient Authorization header to allow API keys that contains '=' characters

Fixes #52 