### PR TITLE
URL Encode query string

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -17,10 +17,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
 using com.inversoft.error;
 using io.fusionauth.converters;
 using Newtonsoft.Json;
@@ -155,14 +155,11 @@ namespace io.fusionauth {
         {
             return uri;
         }
+
+        var encodedParameters = parameters.Select(p => $"{WebUtility.UrlEncode(p.Key)}={WebUtility.UrlEncode(p.Value)}");
+
+        var queryString = string.Join("&", encodedParameters);
         
-        var queryString = HttpUtility.ParseQueryString(string.Empty);
-
-        foreach (var parameter in parameters)
-        {
-            queryString[parameter.Key] = parameter.Value;
-        }
-
         return $"{uri}?{queryString}";
     }
 

--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using com.inversoft.error;
 using io.fusionauth.converters;
 using Newtonsoft.Json;
@@ -150,16 +151,19 @@ namespace io.fusionauth {
     }
 
     private string getFullUri() {
-      var paramString = "?";
-      foreach (var (key, value) in parameters.Select(x => (x.Key, x.Value))) {
-        if (!paramString.EndsWith("?")) {
-          paramString += "&";
+        if (!parameters.Any())
+        {
+            return uri;
+        }
+        
+        var queryString = HttpUtility.ParseQueryString(string.Empty);
+
+        foreach (var parameter in parameters)
+        {
+            queryString[parameter.Key] = parameter.Value;
         }
 
-        paramString += key + "=" + value;
-      }
-
-      return uri + paramString;
+        return $"{uri}?{queryString}";
     }
 
     private Task<HttpResponseMessage> baseRequest() {


### PR DESCRIPTION
Fix for #59

Not sure how to write a unit test for this as the client isn't very unit testable, but here's a dotnetfiddle link that demonstrates the problem and fix: https://dotnetfiddle.net/LL3IuP