### PR TITLE
enable httpClient factory to be used easily

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 
 namespace io.fusionauth {
-  class DefaultRESTClient : IRESTClient {
+  public class DefaultRESTClient : IRESTClient {
     public HttpClient httpClient;
 
     public HttpContent content;
@@ -55,6 +55,10 @@ namespace io.fusionauth {
 
     public DefaultRESTClient(string host) {
       httpClient = new HttpClient {BaseAddress = new Uri(host)};
+    }
+
+    public DefaultRESTClient(HttpClient httpClient) {
+      httpClient = httpClient;
     }
 
     /**


### PR DESCRIPTION
the goal of the PR is to enable an easy implementation of an IRESTClientBuilder that could leverage HttpClientFactory without having to rewrite the DefaultRestClient