### PR TITLE
exposing client builder to allow httpClient.

### DIFF
--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using com.inversoft.error;
@@ -28,7 +29,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 
 namespace io.fusionauth {
-  class DefaultRESTClient : IRESTClient {
+  public class DefaultRESTClient : IRESTClient {
     public HttpClient httpClient;
 
     public HttpContent content;
@@ -55,6 +56,10 @@ namespace io.fusionauth {
 
     public DefaultRESTClient(string host) {
       httpClient = new HttpClient {BaseAddress = new Uri(host)};
+    }
+
+    public DefaultRESTClient(HttpClient incomingHttpClient) {
+      httpClient = incomingHttpClient;
     }
 
     /**
@@ -169,7 +174,18 @@ namespace io.fusionauth {
         // - Bypass this additional validation for the Authorization header. If we find other edge cases, perhaps 
         //   we should just always use TryAddWithoutValidation unless there is a security risk. 
         if (key == "Authorization") {
-          httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
+          if (httpClient.DefaultRequestHeaders.Authorization == null)
+          {
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
+          }
+          else
+          {
+            if (httpClient.DefaultRequestHeaders.Authorization.ToString() != value)
+            {
+              httpClient.DefaultRequestHeaders.Clear();
+              httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
+            }
+          }
         } else {
           httpClient.DefaultRequestHeaders.Add(key, value);
         }

--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -169,23 +169,13 @@ namespace io.fusionauth {
     }
 
     private Task<HttpResponseMessage> baseRequest() {
+      httpClient.Default.RequestHeaders.Clear();
       foreach (var (key, value) in headers.Select(x => (x.Key, x.Value))) {
         // .Add performs additional validation on the 'value' that may fail if an API key contains a '=' character.
         // - Bypass this additional validation for the Authorization header. If we find other edge cases, perhaps 
         //   we should just always use TryAddWithoutValidation unless there is a security risk. 
         if (key == "Authorization") {
-          if (httpClient.DefaultRequestHeaders.Authorization == null)
-          {
-            httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
-          }
-          else
-          {
-            if (httpClient.DefaultRequestHeaders.Authorization.ToString() != value)
-            {
-              httpClient.DefaultRequestHeaders.Clear();
-              httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
-            }
-          }
+          httpClient.DefaultRequestHeaders.TryAddWithoutValidation(key, value);
         } else {
           httpClient.DefaultRequestHeaders.Add(key, value);
         }

--- a/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/DefaultRESTClient.cs
@@ -169,7 +169,7 @@ namespace io.fusionauth {
     }
 
     private Task<HttpResponseMessage> baseRequest() {
-      httpClient.Default.RequestHeaders.Clear();
+      httpClient.DefaultRequestHeaders.Clear();
       foreach (var (key, value) in headers.Select(x => (x.Key, x.Value))) {
         // .Add performs additional validation on the 'value' that may fail if an API key contains a '=' character.
         // - Bypass this additional validation for the Authorization header. If we find other edge cases, perhaps 

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthClient.cs
@@ -3300,4 +3300,24 @@ namespace io.fusionauth {
       return new DefaultRESTClient(host);
     }
   }
+
+  public class HttpClientBuilder : IRESTClientBuilder
+  {
+    public HttpClient HTTP_CLIENT;
+
+    public HttpClientBuilder(HttpClient httpClient)
+    {
+      HTTP_CLIENT = httpClient;
+    }
+
+    public IRESTClient build(string host)
+    {
+      if (HTTP_CLIENT.BaseAddress == null)
+      {
+        HTTP_CLIENT.BaseAddress = new Uri(host);
+      }
+      return new DefaultRESTClient(HTTP_CLIENT);
+    }
+
+  }
 }

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
@@ -34,14 +34,7 @@ namespace io.fusionauth {
     public readonly FusionAuthClient client;
 
     public FusionAuthSyncClient(string apiKey, string host, string tenantId = null, IRESTClientBuilder clientBuilder = null) {
-      if (clientBuilder == null)
-      {
-        client = new FusionAuthClient(apiKey, host, tenantId);
-      }
-      else
-      {
-        client = new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
-      }
+      client = new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
     }
 
     /**

--- a/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
+++ b/fusionauth-netcore-client/src/io/fusionauth/FusionAuthSyncClient.cs
@@ -33,8 +33,15 @@ namespace io.fusionauth {
   public class FusionAuthSyncClient : IFusionAuthSyncClient {
     public readonly FusionAuthClient client;
 
-    public FusionAuthSyncClient(string apiKey, string host, string tenantId = null) {
-      client = new FusionAuthClient(apiKey, host, tenantId);
+    public FusionAuthSyncClient(string apiKey, string host, string tenantId = null, IRESTClientBuilder clientBuilder = null) {
+      if (clientBuilder == null)
+      {
+        client = new FusionAuthClient(apiKey, host, tenantId);
+      }
+      else
+      {
+        client = new FusionAuthClient(apiKey, host, tenantId, clientBuilder);
+      }
     }
 
     /**


### PR DESCRIPTION
DefaultRestClient.cs is the change that will stick.  The changes to FusionAuthClient.cs and FusionAuthSyncClient.cs will have to be added to [fusionauth-client-bulder](https://github.com/FusionAuth/fusionauth-client-builder).  I will add that now.