### PR TITLE
add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,96 @@
+# Run locally with act:
+#
+# act pull_request [--input command=[command]] \
+#  --platform fusionauth-builder=[ecr-repo-name]/fusionauth-builder:latest] \
+#  --workflows ./.github/workflows/release.yaml \
+#  --env-file <(aws configure export-credentials --profile [aws-profile] --format env)
+
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      command:
+        type: choice
+        options:
+          - build    # build only
+          - publish  # build & publish to rubygems
+          - release  # build & release to svn
+        default: build
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' && inputs.command == 'build'
+    runs-on: fusionauth-builder
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      # Install openssl 1.1 because openssl 3.x is not supported by dotnet 5
+      - name: install openssl 1.1
+        run: |
+          wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+          dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+
+      - name: compile
+        shell: bash -l {0}
+        run: sb compile
+
+  deploy:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.command == 'release' || inputs.command == 'publish')
+    runs-on: fusionauth-builder
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: set aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::752443094709:role/github-actions
+          role-session-name: aws-auth-action
+          aws-region: us-west-2
+
+      - name: get secret
+        run: |
+          while IFS=$'\t' read -r key value; do
+            echo "::add-mask::${value}"
+            echo "${key}=${value}" >> $GITHUB_ENV
+          done < <(aws secretsmanager get-secret-value \
+            --region us-west-2 \
+            --secret-id platform/nuget \
+            --query SecretString \
+            --output text | \
+            jq -r 'to_entries[] | [.key, .value] | @tsv')
+
+      # Install openssl 1.1 because openssl 3.x is not supported by dotnet 5 :sad-trombone:
+      - name: install openssl 1.1
+        run: |
+          wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+          dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
+
+      - name: update savant properties file
+        run: echo "nugetAPIKey=${{ env.API_KEY }}" >> ~/.savant/config.properties
+
+      - name: release to svn
+        if: inputs.command == 'release'
+        shell: bash -l {0}
+        run: sb release
+
+      - name: publish to nuget
+        if: inputs.command == 'publish'
+        shell: bash -l {0}
+        run: sb publish

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,12 +38,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      # Install openssl 1.1 because openssl 3.x is not supported by dotnet 5
-      - name: install openssl 1.1
-        run: |
-          wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-          dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-
       - name: compile
         shell: bash -l {0}
         run: sb compile
@@ -75,12 +69,6 @@ jobs:
             --query SecretString \
             --output text | \
             jq -r 'to_entries[] | [.key, .value] | @tsv')
-
-      # Install openssl 1.1 because openssl 3.x is not supported by dotnet 5 :sad-trombone:
-      - name: install openssl 1.1
-        run: |
-          wget http://ports.ubuntu.com/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_arm64.deb
-          dpkg -i libssl1.1_1.1.1f-1ubuntu2_arm64.deb
 
       - name: update savant properties file
         run: echo "nugetAPIKey=${{ env.API_KEY }}" >> ~/.savant/config.properties

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ on:
         type: choice
         options:
           - build    # build only
-          - publish  # build & publish to rubygems
+          - publish  # build & publish to nuget
           - release  # build & release to svn
         default: build
 

--- a/fusionauth-netcore-client/fusionauth-netcore-client.csproj
+++ b/fusionauth-netcore-client/fusionauth-netcore-client.csproj
@@ -12,7 +12,7 @@
         <Owners>FusionAuth</Owners>
         <Summary>FusionAuth client for .NET Core</Summary>
         <LangVersion>7.3</LangVersion>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
         <Company>FusionAuth</Company>
     </PropertyGroup>
 

--- a/fusionauth-netcore-client/fusionauth-netcore-client.csproj
+++ b/fusionauth-netcore-client/fusionauth-netcore-client.csproj
@@ -12,12 +12,12 @@
         <Owners>FusionAuth</Owners>
         <Summary>FusionAuth client for .NET Core</Summary>
         <LangVersion>7.3</LangVersion>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
         <Company>FusionAuth</Company>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.2"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
One change not reflected in this PR is that the library is now being build with dotnet 8, since that is the dotnet version included in the `fusionauth-builder` image that runs this pipeline.

I also want to call out the version changes for targets and dependencies in `fusionauth-netcore-client.csproj` that were made to reduce the number of high-severity vulnerabilities in the older versions.